### PR TITLE
Update icons for many language packs and links to F-Droid/Play Store

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 <a href="https://play.google.com/store/apps/details?id=com.menny.android.anysoftkeyboard&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-AC-global-none-all-co-pr-py-PartBadges-Oct1515-1"><img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/apps/en-play-badge.png" height="80pt"/></a>&nbsp;
 <a href="https://f-droid.org/repository/browse/?fdid=com.menny.android.anysoftkeyboard"><img alt="Get it on F-Droid" src="https://f-droid.org/wiki/images/5/55/F-Droid-button_get-it-on_bigger.png" height="80pt"/></a><br/>
 
-	
+
 </p>
 
 
@@ -95,9 +95,9 @@ If you decide to donate, please specify the feature you liked.</p>
 <td>not yet</td>
 <td>?</td></tr>
 <tr><td>Brazilian</td>
-<td></td>
-<td>?</td>
-<td>not yet</td>
+<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Brazilian/src/main/play/en-US/listing/icon/ask_logo.png" width="48" height="48" /></td>
+<td><a href="https://play.google.com/store/apps/details?id=com.anysoftkeyboard.languagepack.brazilian"><img src="images/play.png" /></a></td>
+<td><a href="https://f-droid.org/en/packages/com.anysoftkeyboard.languagepack.brazilian/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Brazilian"><img src="images/github.png" /></a></td></tr>
 <tr><td>Bulgarian</td>
 <td></td>
@@ -125,9 +125,9 @@ If you decide to donate, please specify the feature you liked.</p>
 <td><a href="https://f-droid.org/packages/com.menny.anysoftkeyboard.finnish/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Finnish"><img src="images/github.png" /></a></td></tr>
 <tr><td>French</td>
-<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/French/StoreStuff/store_hi_res_icon.png" width="48" height="48"/></td>
+<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/French/src/main/play/en-US/listing/icon/ask_logo.png" width="48" height="48"/></td>
 <td><a href="https://play.google.com/store/apps/details?id=com.anysoftkeyboard.languagepack.french"><img src="images/play.png" /></a></td>
-<td>not yet</td>
+<td><a href="https://f-droid.org/en/packages/com.anysoftkeyboard.languagepack.french/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/French"><img src="images/github.png" /></a></td></tr>
 <tr><td>Fulah</td>
 <td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Fulah/StoreStuff/store_hi_res_icon.png" width="48" height="48"/></td>
@@ -135,14 +135,14 @@ If you decide to donate, please specify the feature you liked.</p>
 <td>not yet</td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Fulah"><img src="images/github.png" /></a></td></tr>
 <tr><td>Georgian</td>
-<td></td>
+<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Finnish/StoreStuff/store_hi_res_icon.png" width="48" height="48" /></td>
 <td><a href="https://play.google.com/store/apps/details?id=com.anysoftkeyboard.languagepack.georgian_full"><img src="images/play.png" /></a></td>
 <td>not yet</td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Georgian"><img src="images/github.png" /></a></td></tr>
 <tr><td>German</td>
-<td></td>
+<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/German/src/main/play/en-US/listing/icon/ask_logo.png" width="48" height="48" /></td>
 <td><a href="https://play.google.com/store/apps/details?id=com.anysoftkeyboard.languagepack.german"><img src="images/play.png" /></a></td>
-<td>not yet</td>
+<td><a href="https://f-droid.org/en/packages/com.anysoftkeyboard.languagepack.german/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/German"><img src="images/github.png" /></a></td></tr>
 <tr><td>Greek</td>
 <td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Greek/StoreStuff/store_hi_res_icon.png" width="48" height="48"/></td>
@@ -150,7 +150,7 @@ If you decide to donate, please specify the feature you liked.</p>
 <td><a href="https://f-droid.org/packages/com.anysoftkeyboard.languagepack.greek/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Greek"><img src="images/github.png" /></a></td></tr>
 <tr><td>Hebrew</td>
-<td></td>
+<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Hebrew/src/main/play/en-US/listing/icon/ask_logo.png" width="48" height="48" /></td>
 <td><a href="https://play.google.com/store/apps/details?id=com.anysoftkeyboard.languagepack.hebrew"><img src="images/play.png" /></a></td>
 <td><a href="https://f-droid.org/packages/com.anysoftkeyboard.languagepack.hebrew/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Hebrew"><img src="images/github.png" /></a></td></tr>
@@ -185,7 +185,7 @@ If you decide to donate, please specify the feature you liked.</p>
 <td>not yet</td>
 <td>?</td></tr>
 <tr><td>Portuguese</td>
-<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Portuguese/StoreStuff/store_hi_res_icon.png" width="48" height="48"/></td>
+<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Portuguese/src/main/play/en-US/listing/icon/ask_logo.png" width="48" height="48"/></td>
 <td><a href="https://play.google.com/store/apps/details?id=com.anysoftkeyboard.languagepack.portuguese"><img src="images/play.png" /></a></td>
 <td><a href="https://f-droid.org/packages/com.anysoftkeyboard.languagepack.portuguese/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Portuguese"><img src="images/github.png" /></a></td></tr>
@@ -205,17 +205,17 @@ If you decide to donate, please specify the feature you liked.</p>
 <td>not yet</td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Slovak"><img src="images/github.png" /></a></td></tr>
 <tr><td>Slovene</td>
-<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Slovene/StoreStuff/store_hi_res_icon.png" width="48" height="48"/></td>
+<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Slovene/src/main/play/en-US/listing/icon/ask_logo.png" width="48" height="48"/></td>
 <td><a href="https://play.google.com/store/apps/details?id=com.anysoftkeyboard.languagepack.slovene"><img src="images/play.png" /></a></td>
 <td><a href="https://f-droid.org/packages/com.anysoftkeyboard.languagepack.slovene/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Slovene"><img src="images/github.png" /></a></td></tr>
 <tr><td>Spanish</td>
-<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Spanish/StoreStuff/store_hi_res_icon.png" width="48" height="48"/></td>
+<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Spanish/src/main/play/en-US/listing/icon/ask_logo.png" width="48" height="48"/></td>
 <td><a href="https://play.google.com/store/apps/details?id=com.anysoftkeyboard.languagepack.spain"><img src="images/play.png" /></a></td>
 <td><a href="https://f-droid.org/packages/com.anysoftkeyboard.languagepack.spain/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Spanish"><img src="images/github.png" /></a></td></tr>
 <tr><td>Swedish</td>
-<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Swedish/StoreStuff/store_hi_res_icon.png" width="48" height="48"/></td>
+<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Swedish/StoreStuff/store_hi_res_icon_sv.png" width="48" height="48"/></td>
 <td><a href="https://play.google.com/store/apps/details?id=com.anysoftkeyboard.languagepack.swedish"><img src="images/play.png" /></a></td>
 <td><a href="https://f-droid.org/packages/com.anysoftkeyboard.languagepack.swedish/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Swedish"><img src="images/github.png" /></a></td></tr>
@@ -230,7 +230,7 @@ If you decide to donate, please specify the feature you liked.</p>
 <td><a href="https://f-droid.org/packages/com.anysoftkeyboard.languagepack.tatar/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Tatar"><img src="images/github.png" /></a></td></tr>
 <tr><td>Ukrainian</td>
-<td></td>
+<td><img src="https://raw.githubusercontent.com/AnySoftKeyboard/LanguagePack/Ukrainian/src/main/play/en-US/listing/icon/ask_logo.png" width="48" height="48" /></td>
 <td><a href="https://play.google.com/store/apps/details?id=ch.masshardt.anysoftkeyboard.swisslanguagepack"><img src="images/play.png" /></a></td>
 <td><a href="https://f-droid.org/packages/com.anysoftkeyboard.languagepack.ukrainian/"><img src="images/fdroid.png" /></a></td>
 <td><a href="https://github.com/AnySoftKeyboard/LanguagePack/tree/Ukrainian"><img src="images/github.png" /></a></td></tr>


### PR DESCRIPTION
Note that we built Catalan from the [SVN](https://softkeyboard.googlecode.com/svn/trunk/LanguagePacks/Catalan) but it’s not here anymore and the git repository doesn’t have it.