### PR TITLE
Hide link to inactive RSS

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -7,10 +7,6 @@
   - name: Languages
     link: /languages/
 - links:
-  - name: RSS
-    link: /feed.xml
-    social_icon: RSS
-    new_window: false
   - name: GitHub
     link: https://github.com/AnySoftKeyboard/AnySoftKeyboard
     social_icon: GitHub


### PR DESCRIPTION
It is confusing to link to RSS which has no content.